### PR TITLE
enable OCR High Resolution as default Document Intelligence add-on feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ celerybeat-schedule
 .env
 .venv
 .vscode/
+.azure/
 
 env/
 venv/

--- a/src/functionapp/ai_ocr/azure/doc_intelligence.py
+++ b/src/functionapp/ai_ocr/azure/doc_intelligence.py
@@ -5,7 +5,7 @@ import sys
 import html
 
 from azure.ai.documentintelligence import DocumentIntelligenceClient
-from azure.ai.formrecognizer import DocumentAnalysisClient
+from azure.ai.formrecognizer import DocumentAnalysisClient, AnalysisFeature
 from azure.ai.documentintelligence.models import AnalyzeResult
 from azure.core.credentials import AzureKeyCredential
 from azure.ai.formrecognizer import DocumentAnalysisClient
@@ -20,11 +20,12 @@ client = document_analysis_client = DocumentAnalysisClient(endpoint=config["doc_
                                                                headers={"solution":"ARGUS-1.0"})
                                                             #    **kwargs)
 
-# Get OCR and convert it to HTML
+# Get OCR and convert it to HTML, using ocr_high_resolution feature as default
 def get_ocr_results(file_path: str):
     with open(file_path, "rb") as f:
         poller = client.begin_analyze_document("prebuilt-layout",
-                                               document=f)
+                                               document=f,
+                                               features=[AnalysisFeature.OCR_HIGH_RESOLUTION])
     ocr_result = poller.result()
     return ocr_to_html(ocr_result)
 


### PR DESCRIPTION
## Purpose
to enable high resolution add-on by default in document intelligence, ensure edge cases where documents of large size and high resolution needs high resolution OCR capability to recognize on small texts. 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
it is a one-line change in the doc_intelligence.py file, redeploy the azure function and reprocess a existing document, see if the any error occurs.   