### PR TITLE
Reduce manual steps during deployment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/python:3",
+    "features": {
+      "ghcr.io/devcontainers/features/azure-cli:1": {},
+      "ghcr.io/azure/azure-dev/azd:0": {},
+      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers/features/node:1": {},
+      "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+            "GitHub.remotehub",
+            "GitHub.copilot",
+            "GitHub.copilot-chat",
+            "github.vscode-pull-request-github",
+            "ms-vscode.vscode-node-azure-pack",
+            "ms-toolsai.jupyter",
+            "ms-azuretools.azure-dev",
+            "ms-azuretools.vscode-bicep",
+            "ms-vscode.powershell",
+            "ms-vscode-remote.vscode-remote-extensionpack",
+            "tomoki1207.pdf",
+            "redhat.vscode-yaml",
+            "formulahendry.azure-storage-explorer",
+            "ms-azuretools.vscode-docker",
+            "ms-azuretools.vscode-azureresourcegroups",
+            "ms-azuretools.vscode-azurestorage",
+            "ms-azuretools.vscode-azure-github-copilot",
+            "ms-vscode-remote.remote-containers",
+            "ms-python.black-formatter"
+        ]
+      }
+    },
+    // Add your own post creation commands here
+    // Add the Python packages that you use to requirements.txt
+    "postCreateCommand": "sudo apt update && .devcontainer/install-uv.sh"
+  }
+  

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,6 @@
     },
     // Add your own post creation commands here
     // Add the Python packages that you use to requirements.txt
-    "postCreateCommand": "sudo apt update"
+    "postCreateCommand": "sudo apt update && pip install --upgrade pip && pip install -r frontend/requirements.txt"
   }
   

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
             "ms-azuretools.vscode-azurestorage",
             "ms-azuretools.vscode-azure-github-copilot",
             "ms-vscode-remote.remote-containers",
-            "ms-python.black-formatter"
+            "ms-python.black-formatter",
+            "ms-azuretools.vscode-azurefunctions"
         ]
       }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,6 @@
     },
     // Add your own post creation commands here
     // Add the Python packages that you use to requirements.txt
-    "postCreateCommand": "sudo apt update && .devcontainer/install-uv.sh"
+    "postCreateCommand": "sudo apt update"
   }
   

--- a/.devcontainer/install-uv.sh
+++ b/.devcontainer/install-uv.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-curl -LsSf https://astral.sh/uv/install.sh | sh
-uv sync

--- a/.devcontainer/install-uv.sh
+++ b/.devcontainer/install-uv.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv sync

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Before deploying the solution, you need to create an OpenAI resource and deploy 
 1. **Bicep Template Deployment**:
    - Use the provided `main.bicep` file to deploy resources manually:
      ```sh
-     az deployment group create --resource-group <your-resource-group> --template-file main.bicep
+     az deployment group create --resource-group rg-argus-004 --template-file infra/main.bicep  \
+         --parameters azurePrincipalId=$(az ad signed-in-user show --query id -o tsv)
      ```
 ---
 > **NOTE:** After deployment wait for about 10 minutes for the docker images to be pulled. You can check the progress in your `Azure Portal` > `Resource Group` > `FunctionApp` > `Deployment Center` > `Logs`.
@@ -74,39 +75,17 @@ To run the Streamlit app `app.py` located in the `frontend` folder, follow these
    pip install -r frontend/requirements.txt
    ```
 
-2. Rename the `.env.temp` file to `.env`:
+2. Execute the following command:
+    ```sh
+   azd env get-values > frontend/.env
+    ```
+   Alternatively, **if you did not use AZD to provision the resources**: Rename the `.env.temp` file to `.env`:
    ```sh
    mv frontend/.env.temp frontend/.env
    ```
+   then populate the `.env` file with the necessary environment variables. Open the `.env` file in a text editor and provide the required values for each variable.
 
-3. Populate the `.env` file with the necessary environment variables. Open the `.env` file in a text editor and provide the required values for each variable.
-   > **NOTE:** Your storage account name should be the one starting with `sa-`.
-
-
-4. Assign a CosmsosDB and Blob Storage Role to your Principal ID:
-
-   Get the `principal ID` of the currently signed-in user:
-   ```
-   az ad signed-in-user show --query id -o tsv
-   ```
-   Then, create Cosmos and Blob `role assignments`:
-   ```
-   az cosmosdb sql role assignment create \
-      --principal-id "<principal-id>" \
-      --resource-group "<resource-group-name>" \
-      --account-name "<cosmos-account-name>" \
-      --role-definition-name "Cosmos DB Built-in Data Contributor" \
-      --scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.DocumentDB/databaseAccounts/<cosmos-account-name>"
-   ```
-   ```
-   az role assignment create \
-      --assignee "<principal-id>" \
-      --role "Storage Blob Data Contributor" \
-      --scope "/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.Storage/storageAccounts/<storage-account-name>"
-   ```
-      > **NOTE:** Your storage account name should be the one starting with `sa-`.
-
-5. Start the Streamlit app by running the following command in your terminal:
+3. Start the Streamlit app by running the following command in your terminal:
    ```sh
    streamlit run frontend/app.py
    ```

--- a/azure.yaml
+++ b/azure.yaml
@@ -6,6 +6,11 @@
 
 # Name of the application.
 name: azure-function-app
-
-
-
+hooks:
+  postprovision:
+    posix:
+      shell: sh
+      run: pip install -r frontend/requirements.txt
+    windows:
+      shell: pwsh
+      run: pip install -r frontend/requirements.txt

--- a/frontend/.env.temp
+++ b/frontend/.env.temp
@@ -1,6 +1,6 @@
-BLOB_ACCOUNT_URL=""
+BLOB_ACCOUNT_URL="<Azure Storage Account URL (the one starting with 'sa...')>"
 CONTAINER_NAME="datasets"
-COSMOS_URL=""
+COSMOS_URL="<Cosmos DB URL>"
 COSMOS_DB_NAME="doc-extracts"
 COSMOS_DOCUMENTS_CONTAINER_NAME="documents"
 COSMOS_CONFIG_CONTAINER_NAME="configuration"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -453,6 +453,7 @@ resource userStorageAccountRoleAssignment 'Microsoft.Authorization/roleAssignmen
   }
 }
 
+// TODO: could we remove some of those outputs?
 output resourceGroup string = resourceGroup().name
 output functionAppEndpoint string = functionApp.properties.defaultHostName
 output functionAppName string = functionApp.name
@@ -460,8 +461,6 @@ output storageAccountName string = storageAccount.name
 output containerName string = blobContainer.name
 output storageAccountKey string = listKeys(storageAccount.id, storageAccount.apiVersion).keys[0].value
 
-// TODO: remove secrets from output values
-output BLOB_CONN_STR string = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${storageAccount.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
 output BLOB_ACCOUNT_URL string = storageAccount.properties.primaryEndpoints.blob
 output CONTAINER_NAME string = blobContainer.name
 output COSMOS_URL string = cosmosDbAccount.properties.documentEndpoint

--- a/infra/main.json
+++ b/infra/main.json
@@ -521,6 +521,14 @@
     "storageAccountKey": {
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2022-05-01').keys[0].value]"
+    },
+    "COSMOS_DB_ACCOUNT_NAME": {
+      "type": "string",
+      "value": "[parameters('cosmosDbAccountName')]"
+    },
+    "COSMOS_DB_CONNECTION_STRING": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDbAccountName')), '2021-04-15').documentEndpoint]"
     }
   }
 }

--- a/infra/main.json
+++ b/infra/main.json
@@ -61,6 +61,13 @@
     "roleDefinitionId": {
       "type": "string",
       "defaultValue": "ba92f5b4-2d11-453d-a403-e96b0029c9fe"
+    },
+    "azurePrincipalId": {
+      "type": "string",
+      "metadata": {
+        "description": "The principal ID of the user who will use those resources (usually yourself)"
+      },
+      "defaultValue": "[authorization().principalId]"
     }
   },
   "variables": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -65,9 +65,8 @@
     "azurePrincipalId": {
       "type": "string",
       "metadata": {
-        "description": "The principal ID of the user who will use those resources (usually yourself)"
-      },
-      "defaultValue": "[authorization().principalId]"
+        "description": "The principal ID of the user who will use those resources (usually yourself). You can use the Azure CLI to get this value: az ad signed-in-user show --query id -o tsv"
+      }
     }
   },
   "variables": {
@@ -501,6 +500,34 @@
       "tags": "[variables('commonTags')]",
       "dependsOn": [
         "[resourceId('Microsoft.Web/connections', 'azureblob')]"
+      ]
+    },
+    {
+      "type": "Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments",
+      "apiVersion": "2021-04-15",
+      "name": "[format('{0}/{1}', parameters('cosmosDbAccountName'), guid(parameters('azurePrincipalId'), resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDbAccountName')), resourceId('Microsoft.Web/sites', parameters('functionAppName')), resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('cosmosDbAccountName'), '00000000-0000-0000-0000-000000000002')))]",
+      "properties": {
+        "roleDefinitionId": "[resourceId('Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions', parameters('cosmosDbAccountName'), '00000000-0000-0000-0000-000000000002')]",
+        "principalId": "[parameters('azurePrincipalId')]",
+        "scope": "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDbAccountName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.DocumentDB/databaseAccounts', parameters('cosmosDbAccountName'))]",
+        "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "scope": "[format('Microsoft.Storage/storageAccounts/{0}', parameters('storageAccountName'))]",
+      "name": "[guid(resourceId('Microsoft.Web/sites', parameters('functionAppName')), resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('azurePrincipalId'), 'StorageBlobDataContributor')]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
+        "principalId": "[parameters('azurePrincipalId')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
       ]
     }
   ],

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -7,6 +7,9 @@
       },
       "location": {
         "value": "${AZURE_LOCATION}"
+      },
+      "azurePrincipalId": {
+        "value": "${AZURE_PRINCIPAL_ID}"
       }
     }
 }


### PR DESCRIPTION
## Purpose

Setting up RBAC were additional commands to be run with several parts to edit by the user. This PR allows for a single command AZD deploy and one command configuration setup of  `frontend/.env`
Also added a configuration for DevContainers and Codespaces.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code: 
  * Run `azd up` and `azd env get-values > frontend/.env`
  * Run the one click deployment

## What to Check
Verify that:
* the deployment works
* the frontend still works as before