### PR TITLE
Fix activation command in azure.yaml for virtual environment

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -13,7 +13,7 @@ hooks:
         echo "6. Start Streamlit: streamlit run frontend/app.py\n"
 
         python3 -m venv .venv
-        source .venv/bin/activate
+        . .venv/bin/activate
         pip install -r frontend/requirements.txt
         azd env get-values > frontend/.env
         streamlit run frontend/app.py


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* When running `azd up` from a Linux shell, the postprovision command fails with an error stating `source command not found`. When the `source .venv/bin/activate` command is used to activate the virtual environment, the `source` command is not found because the script is marked with #!/bin/sh and not #!/bin/bash, and the source command is not present in the sh shell. The fix uses `. .venv/bin/activate` to activate the virtual environment, as using dot is compatible with other shells like sh.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

This pull request includes a small change to the `azure.yaml` file. The change modifies the command used to activate the virtual environment in the `hooks:` section.

* [`azure.yaml`](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3L16-R16): Changed `source .venv/bin/activate` to `. .venv/bin/activate` to activate the virtual environment.


<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code from a linux machine or WSL and then:

```
azd up
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* The postprovision command does not show an error stating `source command not found`

## Other Information
<!-- Add any other helpful information that may be needed here. -->