### PR TITLE
Update Python version in devcontainer configuration to 3.12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/python:3",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
     "features": {
       "ghcr.io/devcontainers/features/azure-cli:1": {},
       "ghcr.io/azure/azure-dev/azd:0": {},


### PR DESCRIPTION

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* As the devcontainer does not fix the Python version, now it gets the 3.13.1 version, but this version produces this error when trying to install pandas: `error: standard attributes in middle of decl-specifiers
        422 |         #define CYTHON_UNUSED ...`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

This pull request includes a small change to the `.devcontainer/devcontainer.json` file. The change updates the base image to a more specific version of Python.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L2-R2): Updated the base image from `mcr.microsoft.com/devcontainers/python:3` to `mcr.microsoft.com/devcontainers/python:3.12`.

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Open the project in a devcontainer

```
python3 -m venv .venv
. .venv/bin/activate
pip install -r frontend/requirements.txt
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
N/A
```

## What to Check
Verify that the following are valid
* Installing requirements does not produce an error while installing Pandas

## Other Information
<!-- Add any other helpful information that may be needed here. -->